### PR TITLE
fix map zoom for single itinerary marker

### DIFF
--- a/app/static/js/view-itinerary.js
+++ b/app/static/js/view-itinerary.js
@@ -450,7 +450,12 @@ async function renderMapMarkers() {
         markerCount += 1;
     }
 
-    if (markerCount > 0) {
+    // If only one marker, do not zoom too much - just center on it. If multiple markers, fit bounds.
+    if (markerCount === 1) {
+        const onlyMarker = allMapMarkers[0].marker;
+        map.setCenter(onlyMarker.getPosition());
+        map.setZoom(11);
+    } else if (markerCount > 1) {
         map.fitBounds(bounds);
     }
 }


### PR DESCRIPTION
## Summary

-Related to Issue #89
-Fixed the Google Map zoom level on the view itinerary page when an itinerary only has one map marker.


## Changes

- Updated the map rendering logic so a single marker uses a fixed zoom level instead of `fitBounds()`.
- Adjusted marker focus zoom so the map does not zoom in too closely when users click a card or marker.
- This makes the map easier to understand when there is only one activity location.

## Testing

- Tested an itinerary with a single activity marker.
- Confirmed the map now shows surrounding area instead of zooming too closely into one building.
- Confirmed existing map marker behavior still works.