### PR TITLE
Add CSRF protection for forms and AJAX requests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask
 
 from app.config import Config
-from app.extensions import db, migrate
+from app.extensions import db, migrate, csrf
 from app.routes import main_bp
 
 
@@ -11,6 +11,7 @@ def create_app() -> Flask:
 
     db.init_app(app)
     migrate.init_app(app, db)
+    csrf.init_app(app)
 
     from app import models
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 
@@ -5,6 +6,6 @@ BASE_DIR = Path(__file__).resolve().parent
 
 
 class Config:
-    SECRET_KEY = "dev-secret-key"
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key")
     SQLALCHEMY_DATABASE_URI = f"sqlite:///{BASE_DIR / 'app.db'}"
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,6 +1,7 @@
-from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
-
+from flask_migrate import Migrate
+from flask_wtf.csrf import CSRFProtect
 
 db = SQLAlchemy()
 migrate = Migrate()
+csrf = CSRFProtect()

--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -327,7 +327,7 @@ def signup():
     return render_template("sign-up.html")
 
 # Sign out
-@main_bp.route("/logout")
+@main_bp.route("/logout", methods=["POST"])
 def logout():
     session.pop("user", None)
     return redirect(url_for("main.index"))

--- a/app/static/js/browse-itinerary.js
+++ b/app/static/js/browse-itinerary.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const container = document.getElementById("card-container");
 
-  // 从 Flask API 获取行程数据
+  // 从 Flask API get itineraries data and render cards
   fetch("/api/itineraries")
     .then(res => res.json())
     .then(data => {

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -4,6 +4,10 @@
 // ── DATA — comes from PORTFOLIO_DATA injected by Flask ──
 
 // ── HELPERS ──
+function getCsrfToken() {
+    const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+    return csrfMeta ? csrfMeta.content : "";
+}
 function getInitials(n) { if (!n) return "?"; return n.split(" ").map(w => w[0]).join("").toUpperCase().slice(0, 2); }
 function calcAvg(r) { let t = 0, c = 0; for (let s = 1; s <= 5; s++) { t += s * (r[s] || 0); c += (r[s] || 0); } return c ? t / c : 0; }
 function starsHTML(avg, large = false) {
@@ -18,7 +22,15 @@ document.getElementById("avatar-upload").addEventListener("change", e => {
     const file = e.target.files[0]; if (!file) return;
     const formData = new FormData();
     formData.append("avatar", file);
-    fetch("/api/upload-avatar", { method: "POST", body: formData })
+    
+    fetch("/api/upload-avatar", {
+    method: "POST",
+    headers: {
+        "X-CSRFToken": getCsrfToken()
+    },
+    body: formData
+    })
+    
         .then(r => r.json())
         .then(data => {
             if (!data.success) { alert("Upload failed: " + data.error); return; }
@@ -38,7 +50,15 @@ document.getElementById("banner-upload").addEventListener("change", e => {
     const file = e.target.files[0]; if (!file) return;
     const formData = new FormData();
     formData.append("banner", file);
-    fetch("/api/upload-banner", { method: "POST", body: formData })
+    
+    fetch("/api/upload-banner", {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": getCsrfToken()
+        },
+        body: formData
+    })
+
         .then(r => r.json())
         .then(data => {
             if (!data.success) { alert("Upload failed: " + data.error); return; }

--- a/app/static/js/view-itinerary.js
+++ b/app/static/js/view-itinerary.js
@@ -22,6 +22,11 @@ function tryInitMap() {
     initMap();
 }
 
+// ===== CSRF =====
+function getCsrfToken() {
+    const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+    return csrfMeta ? csrfMeta.content : "";
+}
 
 // ===== DOM RENDER =====
 document.addEventListener("DOMContentLoaded", () => {
@@ -547,6 +552,12 @@ function highlightCard(el) {
 }
 
 // ===== LIKE / FAVORITE / COMMENT =====
+    // 1. 准备一个 POST 请求
+    // 2. 告诉后端：我发的是 JSON
+    // 3. 如果有 body，就 JSON.stringify(body)
+    // 4. fetch 这个 url
+    // 5. 把后端返回的 JSON 转成 JavaScript object
+    // 6. 出错时显示错误信息
 function setupInteractionButtons() {
     const itineraryId = window.location.pathname.split("/").pop();
 
@@ -622,7 +633,8 @@ async function postJson(url, body = null) {
         const options = {
             method: "POST",
             headers: {
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "X-CSRFToken": getCsrfToken()
             }
         };
 
@@ -645,11 +657,15 @@ async function postJson(url, body = null) {
     }
 }
 
+// DELETE comment
 async function deleteComment(commentId) {
     try {
         const res = await fetch(`/api/itinerary/comments/${commentId}`, {
-            method: "DELETE"
-        });
+            method: "DELETE",
+            headers: {
+        "X-CSRFToken": getCsrfToken()   //DELETE need CSRF token
+        }
+    });
 
         const data = await res.json();
 

--- a/app/templates/Submit-form-page.html
+++ b/app/templates/Submit-form-page.html
@@ -154,6 +154,7 @@
         </div>
 
         <form method="POST" action="{{ url_for('main.submit_itinerary') }}" enctype="multipart/form-data" class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"> 
             {% if error %}
                 <div class="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
                     {{ error }}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,9 +47,12 @@
             <a href="{{ url_for('main.portfolio') }}" class="text-sm text-gray-600 hover:text-indigo-600">
               {{ session.get('user') }}
             </a>
-            <a href="{{ url_for('main.logout') }}" class="text-red-600 hover:text-red-700 text-sm">
-              Sign out
-            </a>
+            <form method="POST" action="{{ url_for('main.logout') }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="text-red-600 hover:text-red-700 text-sm">
+                Sign out
+              </button>
+            </form>
           </div>
           {% else %}
           <div class="flex items-center space-x-4">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8" />
+  <meta name="csrf-token" content="{{ csrf_token() }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{% block title %}Travel App{% endblock %}</title>
 

--- a/app/templates/sign-up.html
+++ b/app/templates/sign-up.html
@@ -14,6 +14,7 @@
         <section class="signup-card">
             <h2>Sign Up</h2>
             <form method="POST" action="{{ url_for('main.signup') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <input type="text" placeholder="Choose a username" name="username" required minlength="3" maxlength="20" pattern="[A-Za-z0-9_]+"
                     title="Username must be 3-20 characters and use only letters, numbers, or underscores.">
                 <input type="email" placeholder="Enter your email" name="email" required>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,15 @@
+alembic==1.18.4
+blinker==1.9.0
+click==8.3.3
 Flask==3.1.3
 Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
+Flask-WTF==1.3.0
+itsdangerous==2.2.0
+Jinja2==3.1.6
+Mako==1.3.12
+MarkupSafe==3.0.3
+SQLAlchemy==2.0.49
+typing_extensions==4.15.0
+Werkzeug==3.1.8
+WTForms==3.2.2


### PR DESCRIPTION
## Summary
This PR adds CSRF protection across the Flask travel itinerary web app to protect form submissions and AJAX requests.

## Changes
- Implemented backend CSRF protection using Flask-WTF / CSRFProtect.
- Initialized CSRF protection in `app/__init__.py`.
- Added CSRF protection for sign out by changing logout to a POST request and adding a CSRF token in `base.html`.
- Added CSRF tokens to sign-in and sign-up forms.
- Added CSRF headers to itinerary interaction AJAX requests:
  - like itinerary
  - favorite itinerary
  - post comment
  - delete comment
- Added CSRF headers to portfolio image upload requests:
  - upload avatar photo
  - upload banner photo
- Updated project dependencies to include Flask-WTF.

## Related commits
- `e796c3c` add csrf for sign out in base.html and main_routes.py
- `1a376db` add csrf for sign-in and sign-up.html
- `010f081` add CSRF on portfolio.js for upload avatar and banner photo
- `af68a83` add CSRF on view-itinerary.js for like, favorite, comment, delete comment
- `c56f99d` implement backend csrf protect
- `ea5e534` add csrf on app/init.py

## Testing
- Ran the Flask app locally.
- Verified pages load without CSRF import errors after adding Flask-WTF.
- Tested or prepared CSRF coverage for:
  - sign in
  - sign up
  - sign out
  - submit itinerary
  - like/favorite itinerary
  - add/delete comments
  - avatar/banner upload