### PR TITLE
fixed link on portfolio page to itinerary

### DIFF
--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -184,7 +184,7 @@ function renderItineraries(itineraries) {
         const avg = calcAvg(it.ratings || {});
         const li = document.createElement("li");
         const link = document.createElement("a");
-        link.href = `post-interface.html?id=${it.id}`;
+        link.href = `/itinerary/${it.id}`;
         link.className = "itinerary-card block bg-white border border-gray-200 rounded-xl overflow-hidden no-underline text-inherit flex flex-col shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200";
         link.dataset.country = it.location;
         link.innerHTML = `


### PR DESCRIPTION
closes #79 

## What was wrong
When clicking on an itinerary card on the portfolio page, it was redirecting to /post-interface.html?id=1 which does not exist as a Flask route, causing a "Not Found" error. thanks to Zihui

## What I changed
- Updated the itinerary card link in portfolio-page.js  from `post-interface.html?id=${it.id}` to  `/itinerary/${it.id}` to match the existing Flask route