### PR TITLE
Fix country flags to use flagcdn images for windows compatibility

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,6 @@ from app.config import Config
 from app.extensions import db, migrate, csrf, login
 from app.forms import LogoutForm
 from app.routes import main_bp
-from app.routes.main_routes import country_to_flag
 
 
 def create_app() -> Flask:
@@ -20,7 +19,6 @@ def create_app() -> Flask:
     from app import models
 
     app.register_blueprint(main_bp)
-    app.jinja_env.filters['flag'] = country_to_flag
 
     @app.context_processor
     def inject_logout_form():

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -8,6 +8,16 @@ function getCsrfToken() {
     const csrfMeta = document.querySelector('meta[name="csrf-token"]');
     return csrfMeta ? csrfMeta.content : "";
 }
+
+const COUNTRY_CODES = {
+    "Australia": "au", "Canada": "ca", "China": "cn", "France": "fr",
+    "Germany": "de", "Indonesia": "id", "Italy": "it", "Japan": "jp",
+    "Malaysia": "my", "New Zealand": "nz", "Singapore": "sg",
+    "South Korea": "kr", "Spain": "es", "Switzerland": "ch",
+    "Thailand": "th", "United Kingdom": "gb", "United States": "us",
+    "Vietnam": "vn"
+};
+
 function getInitials(n) { if (!n) return "?"; return n.split(" ").map(w => w[0]).join("").toUpperCase().slice(0, 2); }
 function calcAvg(r) { let t = 0, c = 0; for (let s = 1; s <= 5; s++) { t += s * (r[s] || 0); c += (r[s] || 0); } return c ? t / c : 0; }
 function starsHTML(avg, large = false) {
@@ -211,7 +221,8 @@ function renderCountries(countries) {
         const btn = document.createElement("button");
         btn.className = "country-tag";
         btn.style.setProperty("--expanded-width", (52 + 8 + (country.length * 8.5) + 14) + "px");
-        btn.innerHTML = `<span class="flag-circle">${data.flag}</span><span class="country-name">${country}</span>`;
+        const code = COUNTRY_CODES[country] || "un";
+        btn.innerHTML = `<span class="flag-circle"><img src="https://flagcdn.com/w40/${code}.png" alt="${country}" class="w-7 h-5 object-cover rounded-sm"></span><span class="country-name">${country}</span>`;
         btn.addEventListener("click", () => filterByCountry(country, btn));
         li.appendChild(btn);
         list.appendChild(li);

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -92,7 +92,7 @@
         banner_url: "{{ url_for('static', filename=user.banner_url) if user and user.banner_url else '' }}",
         countries: {
             {% for it in itineraries %}
-                "{{ it.country }}": { flag: "{{ it.country | flag }}"}{% if not loop.last %}, {% endif %}
+                "{{ it.country }}": { flag: ""}{% if not loop.last %}, {% endif %}
             {% endfor %}
         },
          itineraries: [


### PR DESCRIPTION
## Changes
- Replaced flag emojis with flagcdn.com images for cross-platform compatibility
- Flag emojis don't render on Windows — now using actual flag images instead
- Added `COUNTRY_CODES` map in `portfolio-page.js` to map country names to 2-letter codes
- Removed `country_to_flag` Jinja filter from `__init__.py` and `main_routes.py` as no longer needed
- Updated `portfolio-page.html` to remove emoji flag reference