### PR TITLE
Remove ratings

### DIFF
--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -203,9 +203,9 @@ function renderItineraries(itineraries) {
                 <div class="text-xs text-gray-500">📍 ${it.location}</div>
             </div>
             <div class="px-3 pb-3 pt-2 border-t border-gray-200 flex items-center gap-2 text-xs text-gray-500">
-                <span>❤️ ${it.likes}</span>
-                <span>🔖 ${it.saves}</span>
-            </div>`;
+                <span>👍🏼 ${it.likes}</span>
+                <span>${it.favorited_by_me ? '⭐️' : '☆'} ${it.saves}</span>
+             </div>`;
         li.appendChild(link);
         grid.appendChild(li);
     });

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -19,11 +19,6 @@ const COUNTRY_CODES = {
 };
 
 function getInitials(n) { if (!n) return "?"; return n.split(" ").map(w => w[0]).join("").toUpperCase().slice(0, 2); }
-function calcAvg(r) { let t = 0, c = 0; for (let s = 1; s <= 5; s++) { t += s * (r[s] || 0); c += (r[s] || 0); } return c ? t / c : 0; }
-function starsHTML(avg, large = false) {
-    const cls = large ? "text-xl text-yellow-400" : "text-xs text-gray-300";
-    return [1, 2, 3, 4, 5].map(i => `<span class="${cls} ${i <= Math.round(avg) ? "!text-yellow-400" : ""}">★</span>`).join("");
-}
 
 // ── UPLOAD VALIDATION ──
 const VALID_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
@@ -148,41 +143,6 @@ function clearFilter() {
     document.querySelectorAll("#itineraries-grid li").forEach(li => li.style.display = "");
 }
 
-// ── RATING POPUP ──
-const overlay = document.getElementById("rating-overlay");
-const popup = document.getElementById("rating-popup");
-function closePopup() {
-    overlay.classList.remove("opacity-100", "pointer-events-auto");
-    overlay.classList.add("opacity-0", "pointer-events-none");
-    popup.classList.add("translate-y-3");
-}
-const popupClose = document.getElementById("popup-close");
-if (popupClose) popupClose.addEventListener("click", closePopup);
-if (overlay) overlay.addEventListener("click", e => { if (e.target === overlay) closePopup(); });
-
-function openRatingPopup(it) {
-    const avg = calcAvg(it.ratings || {}), total = Object.values(it.ratings || {}).reduce((s, n) => s + n, 0);
-    document.getElementById("popup-trip-title").textContent = it.title;
-    document.getElementById("popup-avg-score").textContent = avg.toFixed(1);
-    document.getElementById("popup-total-ratings").textContent = total + " ratings";
-    document.getElementById("popup-stars-large").innerHTML = starsHTML(avg, true);
-    const bars = document.getElementById("rating-bars");
-    bars.innerHTML = "";
-    for (let s = 5; s >= 1; s--) {
-        const n = it.ratings?.[s] || 0, pct = total ? Math.round(n / total * 100) : 0;
-        bars.innerHTML += `
-            <div class="flex items-center gap-2 text-xs">
-                <span class="w-5 text-right text-gray-500 font-semibold">${s}★</span>
-                <div class="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
-                    <div class="h-full bg-yellow-400 rounded-full" style="width:${pct}%"></div>
-                </div>
-                <span class="w-5 text-gray-500">${n}</span>
-            </div>`;
-    }
-    overlay.classList.remove("opacity-0", "pointer-events-none");
-    overlay.classList.add("opacity-100", "pointer-events-auto");
-    popup.classList.remove("translate-y-3");
-}
 
 // ── RENDER ──
 function renderProfile(user) {
@@ -198,17 +158,6 @@ function renderProfile(user) {
     document.getElementById("stat-countries").textContent = Object.keys(user.countries).length;
     document.getElementById("stat-posts").textContent = user.itineraries.length;
 
-    // Overall average rating across all itineraries
-    const allRatings = user.itineraries.flatMap(it => {
-        const r = it.ratings || {};
-        return Object.entries(r).flatMap(([stars, count]) => Array(count).fill(Number(stars)));
-    });
-    const avgRating = allRatings.length ? allRatings.reduce((a, b) => a + b, 0) / allRatings.length : 0;
-    document.getElementById("stat-rating").textContent = allRatings.length ? avgRating.toFixed(1) : "—";
-    document.getElementById("stat-rating-stars").innerHTML = allRatings.length ? starsHTML(avgRating) : "";
-
-    renderCountries(user.countries);
-    renderItineraries(user.itineraries);
 }
 
 function renderCountries(countries) {
@@ -238,7 +187,6 @@ function renderItineraries(itineraries) {
     }
     const colors = ["#DBEAFE", "#FEF3C7", "#D1FAE5", "#FCE7F3"];
     itineraries.forEach((it, i) => {
-        const avg = calcAvg(it.ratings || {});
         const li = document.createElement("li");
         const link = document.createElement("a");
         link.href = `/itinerary/${it.id}`;
@@ -257,13 +205,7 @@ function renderItineraries(itineraries) {
             <div class="px-3 pb-3 pt-2 border-t border-gray-200 flex items-center gap-2 text-xs text-gray-500">
                 <span>❤️ ${it.likes}</span>
                 <span>🔖 ${it.saves}</span>
-                <span class="ml-auto card-stars cursor-pointer px-1 py-0.5 rounded hover:bg-yellow-50 transition-colors" title="See ratings">
-                    ${starsHTML(avg)}<span class="text-yellow-500 font-bold ml-0.5">${avg.toFixed(1)}</span>
-                </span>
             </div>`;
-        link.querySelector(".card-stars").addEventListener("click", e => {
-            e.preventDefault(); e.stopPropagation(); openRatingPopup(it);
-        });
         li.appendChild(link);
         grid.appendChild(li);
     });
@@ -288,3 +230,5 @@ if (PORTFOLIO_DATA.banner_url) {
 }
 
 renderProfile(PORTFOLIO_DATA);
+renderCountries(PORTFOLIO_DATA.countries);
+renderItineraries(PORTFOLIO_DATA.itineraries);

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -90,19 +90,19 @@
                 "{{ it.country }}": { flag: ""}{% if not loop.last %}, {% endif %}
             {% endfor %}
         },
-         itineraries: [
-            {% for it in itineraries %}
-            {
-                id: {{ it.id }},
-                title: {{ it.title | tojson }},
-                location: {{ it.country | tojson }},
-                cover_image_url: {{ (('/static/' + it.cover_image_url) if it.cover_image_url else '') | tojson }},
-                total_days: {{ it.total_days }},
-                trip_types: {{ it.trip_types | tojson }},
-                likes: 0,
-                saves: 0,
-                ratings: {}
-            }{% if not loop.last %},{% endif %}
+        itineraries: [
+             {% for it in itineraries %}
+                {
+                    id: {{ it.id }},
+                    title: {{ it.title | tojson }},
+                    location: {{ it.country | tojson }},
+                    cover_image_url: {{ (('/static/' + it.cover_image_url) if it.cover_image_url else '') | tojson }},
+                    total_days: {{ it.total_days }},
+                    trip_types: {{ it.trip_types | tojson }},
+                    likes: {{ it.likes | length }},
+                    saves: {{ it.favorites | length }},
+                    favorited_by_me: {{ (current_user in it.favorites | map(attribute='user')) | tojson }}
+                }{% if not loop.last %},{% endif %}
             {% endfor %}
         ]
     };

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -48,11 +48,6 @@
                 <span class="block text-2xl font-bold text-blue-900" id="stat-posts">0</span>
                 <span class="text-xs uppercase tracking-widest text-gray-500">Trips</span>
             </div>
-            <div class="flex-1 py-5 text-center">
-                <span class="block text-2xl font-bold text-blue-900" id="stat-rating">—</span>
-                <span id="stat-rating-stars"></span>
-                <span class="text-xs uppercase tracking-widest text-gray-500">Rating</span>
-            </div>
         </div>
 
         <!-- COUNTRIES -->


### PR DESCRIPTION
Closes #79 #122

## Changes
- Removed the broken ratings system from the portfolio page since it wasn't fully implemented
- Cleaned up leftover rating functions (calcAvg, starsHTML, rating popup)
- Removed the ratings stat from the profile stats section
- Fixed itineraries and countries not showing on the portfolio page
- Hooked up real likes and favourites counts from the database instead of hardcoded 0s
- Added a ⭐️ indicator on cards so you can see which ones you've favorited