### PR TITLE
Fix edit/delete button

### DIFF
--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -1010,3 +1010,20 @@ def portfolio():
         user=current_user,
         itineraries=itineraries
     )
+
+@main_bp.route("/api/itinerary/<int:id>/delete", methods=["DELETE"])
+@login_required
+def delete_itinerary(id):
+    current_user, error_response = require_login_json()
+    if error_response:
+        return error_response
+
+    itinerary = Itinerary.query.get_or_404(id)
+
+    if itinerary.user_id != current_user.id:
+        return jsonify({"success": False, "error": "You can only delete your own itineraries."}), 403
+
+    db.session.delete(itinerary)
+    db.session.commit()
+
+    return jsonify({"success": True})

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -203,6 +203,11 @@ function renderItineraries(itineraries) {
 
         const link = document.createElement("a");
         link.href = `/itinerary/${it.id}`;
+        link.addEventListener("click", (e) => {
+            if (document.getElementById("global-edit-btn").classList.contains("active")) {
+                e.preventDefault();
+            }
+        });
         link.className = "itinerary-card block bg-white border border-gray-200 rounded-xl overflow-hidden no-underline text-inherit flex flex-col shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200";
         link.dataset.country = it.location;
         link.innerHTML = `

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -206,6 +206,10 @@ function renderItineraries(itineraries) {
         link.addEventListener("click", (e) => {
             if (document.getElementById("global-edit-btn").classList.contains("active")) {
                 e.preventDefault();
+                const msg = document.getElementById("edit-mode-msg");
+                msg.classList.remove("hidden");
+                clearTimeout(msg._hideTimer);
+                msg._hideTimer = setTimeout(() => msg.classList.add("hidden"), 2500);
             }
         });
         link.className = "itinerary-card block bg-white border border-gray-200 rounded-xl overflow-hidden no-underline text-inherit flex flex-col shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200";

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -68,8 +68,11 @@
             <span id="filter-country-name" class="font-bold"></span>
             <button onclick="clearFilter()" class="ml-auto text-xs text-gray-500 hover:text-red-500 transition-colors">✕ Clear filter</button>
         </div>
+        <div id="edit-mode-msg" class="hidden text-xs text-blue-600 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 mb-3">
+        ✏️ You're in edit mode — click 🗑 Delete on a card to remove it, or click <strong>Edit</strong> again to exit.
+        </div>
 
-          <ul id="itineraries-grid" class="grid grid-cols-4 gap-3.5 list-none"></ul>
+        <ul id="itineraries-grid" class="grid grid-cols-4 gap-3.5 list-none"></ul>
 
           <a href="{{ url_for('main.submit_itinerary') }}" class="flex flex items-center justify-center gap-2 w-full py-4 mt-5 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-500 no-underline hover:border-blue-400 hover:text-blue-500 hover:bg-blue-50 transition-colors duration-150">
             + Write a new itinerary


### PR DESCRIPTION
Closes #116

## Add delete itinerary feature

Adds the ability for users to delete their own itineraries from the portfolio page.

### Changes
- Added global ✏️ Edit button on the My Itineraries header
- Clicking Edit toggles edit mode (button turns dark blue)
- In edit mode, a 🗑 Delete overlay appears on each card's cover image
- Clicking Delete shows a confirmation popup before deleting
- On confirm, card is removed from the page and stats update instantly
- Clicking a card in edit mode is blocked and shows a hint message
- Backend DELETE route added to `/api/itinerary/<id>/delete` with ownership check
