### PR TITLE
Fix authentication tests and logout selector consistency

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -22,7 +22,13 @@ class SignUpForm(FlaskForm):
             ),
         ],
     )
-    email = StringField("Email", validators=[DataRequired(), Email()])
+    email = StringField(
+        "Email",
+        validators=[
+            DataRequired(),
+            Email(message="Please enter a valid email address."),
+        ],
+    )
     password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
     confirm_password = PasswordField(
         "Confirm Password",

--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -107,6 +107,18 @@ def submit_error_response(message: str, form=None):
     return render_template("Submit-form-page.html", form=form, error=message)
 
 
+def get_form_error_message(form, default_message="Please check the submitted form and try again."):
+    csrf_token = getattr(form, "csrf_token", None)
+    if csrf_token and getattr(csrf_token, "errors", None):
+        return csrf_token.errors[0]
+
+    all_errors = [error for errors in form.errors.values() for error in errors]
+    if all_errors:
+        return all_errors[0]
+
+    return default_message
+
+
 def get_uploaded_file_size(file_storage) -> int:
     stream = file_storage.stream
     current_position = stream.tell()
@@ -373,9 +385,7 @@ def signin():
 
     # validate_on_submit() checks both request method and CSRF token validity.
     if request.method == "POST" and not form.validate_on_submit():
-        error_message = next(
-            iter(form.csrf_token.errors or ["Please check the submitted form and try again."])
-        )
+        error_message = get_form_error_message(form)
         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
             return jsonify({"success": False, "error": error_message}), 400
         return render_template("sign-in.html", form=form, error=error_message)
@@ -422,9 +432,7 @@ def signup():
 
     # Reject invalid or forged form submissions before custom signup checks.
     if request.method == "POST" and not form.validate_on_submit():
-        error_message = next(
-            iter(form.csrf_token.errors or [error for errors in form.errors.values() for error in errors] or ["Please check the submitted form and try again."])
-        )
+        error_message = get_form_error_message(form)
         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
             return jsonify({"success": False, "error": error_message}), 400
         return render_template("sign-up.html", form=form, error=error_message)
@@ -532,9 +540,7 @@ def submit_itinerary():
     form = SubmitItineraryForm()
 
     if request.method == "POST" and not form.validate_on_submit():
-        error_message = next(
-            iter(form.csrf_token.errors or ["Please check the submitted form and try again."])
-        )
+        error_message = get_form_error_message(form)
         return submit_error_response(error_message, form=form)
 
     if form.validate_on_submit():

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,7 +68,7 @@
                 {{ logout_form.hidden_tag() }}
                 <button
                   type="submit"
-                  aria-label="Logout"
+                  aria-label="Sign out"
                   class="group relative flex h-9 w-9 cursor-pointer items-center justify-start overflow-hidden rounded-full bg-red-600 shadow-lg transition-all duration-200 hover:w-28 hover:rounded-lg active:translate-x-1 active:translate-y-1"
                 >
                   <div class="flex w-full items-center justify-center transition-all duration-300 group-hover:justify-start group-hover:px-3">
@@ -79,7 +79,7 @@
                     </svg>
                   </div>
                   <div class="absolute right-4 translate-x-full text-sm font-semibold text-white opacity-0 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100">
-                    Logout
+                    Sign out
                   </div>
                 </button>
               </form>


### PR DESCRIPTION
This fixes two issues in the authentication-related tests.

First, when form validation fails, the test no longer assumes that `csrf_token` always exists. This avoids triggering an `AttributeError` in the unit test environment where CSRF is disabled.

Second, the email validation error message has been standardised so that it matches the test assertion.

Another small fix is that the logout button text in the desktop navigation has been changed to `Sign out`, keeping it consistent with the selector used in the system test.