### PR TITLE
Fix duplicate delete route and add favourited_ids to portfolio

### DIFF
--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -1028,26 +1028,13 @@ def portfolio():
     itineraries = Itinerary.query.filter_by(
         user_id=current_user.id
     ).all()
+
+    favourited_ids = [f.itinerary_id for f in current_user.favorites]
     
     return render_template(
         "portfolio-page.html",
         user=current_user,
-        itineraries=itineraries
+        itineraries=itineraries,
+        favourited_ids=favourited_ids
     )
 
-@main_bp.route("/api/itinerary/<int:id>/delete", methods=["DELETE"])
-@login_required
-def delete_itinerary(id):
-    current_user, error_response = require_login_json()
-    if error_response:
-        return error_response
-
-    itinerary = Itinerary.query.get_or_404(id)
-
-    if itinerary.user_id != current_user.id:
-        return jsonify({"success": False, "error": "You can only delete your own itineraries."}), 403
-
-    db.session.delete(itinerary)
-    db.session.commit()
-
-    return jsonify({"success": True})


### PR DESCRIPTION
## Changes

- Removed the duplicate `delete_itinerary` route that was causing the app to crash on startup
- Added `favourited_ids` to the portfolio route so the favourites filter on the frontend knows which itineraries the user has saved