### PR TITLE
fixed the deletion for deleting itineraries

### DIFF
--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -1004,7 +1004,6 @@ def upload_banner():
 
 # Portfolio page — delete own itinerary
 @main_bp.route("/api/itinerary/<int:id>/delete", methods=["DELETE"])
-@login_required
 def delete_itinerary(id):
     current_user, error_response = require_login_json()
     if error_response:


### PR DESCRIPTION
closes #139 

## What I did
Fixed the "something went wrong" error when deleting itineraries from the portfolio page.

## Why it was broken
The `delete_itinerary` route had both `@login_required` and `require_login_json()` on it. Flask-Login's `@login_required` was running first and returning an HTML redirect instead of JSON, so the frontend fetch call just exploded trying to parse it.

## How I fixed it
- Removed the redundant `@login_required` decorator from `delete_itinerary` in `main_routes.py`
- `require_login_json()` already handles auth for API routes and returns a proper JSON 401, so it didn't need both