### PR TITLE
changed set height

### DIFF
--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -245,7 +245,7 @@ function renderItineraries(itineraries) {
         link.className = "itinerary-card block bg-white border border-gray-200 rounded-xl overflow-hidden no-underline text-inherit flex flex-col shadow-sm hover:-translate-y-1 hover:shadow-lg transition-all duration-200";
         link.dataset.country = it.location;
         link.innerHTML = `
-            <div class="overflow-hidden relative" style="background:${colors[i % colors.length]}; max-height:230px;">
+            <div class="overflow-hidden relative" style="background:${colors[i % colors.length]}; height:230px;">
                 ${it.cover_image_url
                     ? `<img src="${it.cover_image_url}" class="w-full h-full object-cover">`
                     : `<div class="w-full h-full flex items-center justify-center text-4xl">✈️</div>`}


### PR DESCRIPTION
closes #140 

## changes
Fixed inconsistent itinerary card sizes on the portfolio page.
- Changed the cover image container in `portfolio-page.js` from `max-height: 230px` to `height: 160px`
- `object-cover` already handles cropping so images still look good at any size