### PR TITLE
Add change password feature

### DIFF
--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -1036,4 +1036,27 @@ def portfolio():
         itineraries=itineraries,
         favourited_ids=favourited_ids
     )
+# Change password
+@main_bp.route("/api/change-password", methods=["POST"])
+@login_required
+def change_password():
+    current_user = get_current_user()
+    payload = request.get_json(silent=True) or {}
+    
+    current_password = payload.get("current_password", "")
+    new_password = payload.get("new_password", "")
+    confirm_password = payload.get("confirm_password", "")
 
+    if not current_user.check_password(current_password):
+        return jsonify({"success": False, "error": "Current password is incorrect."}), 400
+
+    if len(new_password) < PASSWORD_MIN_LENGTH:
+        return jsonify({"success": False, "error": f"Password must be at least {PASSWORD_MIN_LENGTH} characters."}), 400
+
+    if new_password != confirm_password:
+        return jsonify({"success": False, "error": "Passwords do not match."}), 400
+
+    current_user.set_password(new_password)
+    db.session.commit()
+
+    return jsonify({"success": True})

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -316,6 +316,63 @@ function blockClick(e) {
     e.stopPropagation();
 }
 
+// ── CHANGE PASSWORD MODAL ──
+document.getElementById("change-password-btn").addEventListener("click", () => {
+    document.getElementById("change-password-modal").classList.remove("hidden");
+});
+
+document.getElementById("cancel-password-btn").addEventListener("click", () => {
+    document.getElementById("change-password-modal").classList.add("hidden");
+    document.getElementById("current-password").value = "";
+    document.getElementById("new-password").value = "";
+    document.getElementById("confirm-password").value = "";
+    document.getElementById("password-error").classList.add("hidden");
+    document.getElementById("password-success").classList.add("hidden");
+});
+
+document.getElementById("save-password-btn").addEventListener("click", () => {
+    const currentPassword = document.getElementById("current-password").value;
+    const newPassword = document.getElementById("new-password").value;
+    const confirmPassword = document.getElementById("confirm-password").value;
+    const errorEl = document.getElementById("password-error");
+    const successEl = document.getElementById("password-success");
+
+    errorEl.classList.add("hidden");
+    successEl.classList.add("hidden");
+
+    fetch("/api/change-password", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-CSRFToken": getCsrfToken()
+        },
+        body: JSON.stringify({
+            current_password: currentPassword,
+            new_password: newPassword,
+            confirm_password: confirmPassword
+        })
+    })
+    .then(r => r.json())
+    .then(data => {
+        if (data.success) {
+            successEl.classList.remove("hidden");
+            setTimeout(() => {
+                document.getElementById("change-password-modal").classList.add("hidden");
+                document.getElementById("current-password").value = "";
+                document.getElementById("new-password").value = "";
+                document.getElementById("confirm-password").value = "";
+                successEl.classList.add("hidden");
+            }, 1500);
+        } else {
+            errorEl.textContent = data.error;
+            errorEl.classList.remove("hidden");
+        }
+    })
+    .catch(() => {
+        errorEl.textContent = "Something went wrong.";
+        errorEl.classList.remove("hidden");
+    });
+});
 
 // Restore saved avatar and banner on page load
 if (PORTFOLIO_DATA.avatar_url) {

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -347,6 +347,13 @@ document.getElementById("save-password-btn").addEventListener("click", () => {
         return;
     }
 
+    // Same password validation
+    if (currentPassword === newPassword) {
+        errorEl.textContent = "New password must be different from your current password.";
+        errorEl.classList.remove("hidden");
+        return;
+    }
+
     fetch("/api/change-password", {
         method: "POST",
         headers: {

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -340,6 +340,13 @@ document.getElementById("save-password-btn").addEventListener("click", () => {
     errorEl.classList.add("hidden");
     successEl.classList.add("hidden");
 
+     // Empty field validation
+    if (!currentPassword || !newPassword || !confirmPassword) {
+        errorEl.textContent = "Please fill out all fields.";
+        errorEl.classList.remove("hidden");
+        return;
+    }
+
     fetch("/api/change-password", {
         method: "POST",
         headers: {

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -35,8 +35,10 @@
             <input type="file" id="avatar-upload" accept="image/*" class="hidden">
         </div>
         <div>
-            <div class="text-xl font-bold text-gray-900 mb-0.5" id="username">{{ user.username if user else '' }}</div>
+        <div class="text-xl font-bold text-gray-900 mb-0.5" id="username">{{ user.username if user else '' }}</div>
             <span class="inline-block bg-blue-50 text-blue-600 text-xs font-semibold px-3 py-0.5 rounded-full" id="uid"></span>
+            <br>
+            <button id="change-password-btn" class="text-xs text-blue-600 hover:underline mt-1">Change password</button>
         </div>
     </div>
 

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -87,6 +87,24 @@
         </a>
 
     </div>
+
+    <!-- Change Password Modal -->
+    <div id="change-password-modal" class="hidden fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+        <div class="bg-white rounded-xl p-6 w-full max-w-sm shadow-xl">
+            <h2 class="text-lg font-bold text-blue-900 mb-4">Change Password</h2>
+            <div class="flex flex-col gap-3">
+                <input id="current-password" type="password" placeholder="Current password" class="border border-gray-300 rounded-lg px-3 py-2 text-sm w-full">
+                <input id="new-password" type="password" placeholder="New password" class="border border-gray-300 rounded-lg px-3 py-2 text-sm w-full">
+                <input id="confirm-password" type="password" placeholder="Confirm new password" class="border border-gray-300 rounded-lg px-3 py-2 text-sm w-full">
+                <p id="password-error" class="text-red-500 text-xs hidden"></p>
+                <p id="password-success" class="text-green-500 text-xs hidden">Password changed successfully!</p>
+            </div>
+            <div class="flex gap-2 mt-4">
+                <button id="cancel-password-btn" class="flex-1 py-2 rounded-lg border border-gray-300 text-sm text-gray-600 hover:bg-gray-50">Cancel</button>
+                <button id="save-password-btn" class="flex-1 py-2 rounded-lg bg-blue-900 text-white text-sm hover:bg-blue-800">Save</button>
+            </div>
+        </div>
+    </div>
 </main>
 {% endblock %}
 


### PR DESCRIPTION
closes #141 

- Added `/api/change-password` route in `main_routes.py`
- Added change password modal to `portfolio-page.html`
- Added change password button to the profile card
- Added JS to handle the modal open/close and form submission in `portfolio-page.js`
- Added validation for empty fields, same password, and mismatched passwords