### PR TITLE
Favourites error

### DIFF
--- a/app/routes/main_routes.py
+++ b/app/routes/main_routes.py
@@ -1024,16 +1024,26 @@ def delete_itinerary(id):
 def portfolio():
     current_user = get_current_user()
     
-    itineraries = Itinerary.query.filter_by(
+    # User's own itineraries only (shown by default)
+    own_itineraries = Itinerary.query.filter_by(
         user_id=current_user.id
     ).all()
 
+    # Itineraries favourited by the user (including other people's)
     favourited_ids = [f.itinerary_id for f in current_user.favorites]
-    
+    favourited_itineraries = Itinerary.query.filter(
+        Itinerary.id.in_(favourited_ids),
+        Itinerary.user_id != current_user.id
+    ).all()
+
+    # All itineraries to pass to template (own + favourited others)
+    own_ids = {it.id for it in own_itineraries}
+    all_itineraries = own_itineraries + [it for it in favourited_itineraries if it.id not in own_ids]
+
     return render_template(
         "portfolio-page.html",
         user=current_user,
-        itineraries=itineraries,
-        favourited_ids=favourited_ids
+        itineraries=all_itineraries,
+        favourited_ids=favourited_ids,
+        own_itinerary_ids=[it.id for it in own_itineraries]
     )
-

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -154,7 +154,10 @@ function clearFilter() {
     });
     document.getElementById("filter-notice").classList.add("hidden");
     document.getElementById("filter-notice").classList.remove("flex");
-    document.querySelectorAll("#itineraries-grid li").forEach(li => li.style.display = "");
+    document.querySelectorAll("#itineraries-grid li").forEach(li => {
+        const id = parseInt(li.dataset.itineraryId);
+        li.style.display = PORTFOLIO_DATA.own_itinerary_ids.includes(id) ? "" : "none";
+    });
 }
 
 // -- FAVOURITES FILTER --
@@ -176,9 +179,12 @@ document.getElementById("favourites-filter-btn").addEventListener("click", () =>
             li.style.display = PORTFOLIO_DATA.favourited_ids.includes(id) ? "" : "none";
         });
     } else {
-        btn.classList.remove("active");
-        document.querySelectorAll("#itineraries-grid li").forEach(li => li.style.display = "");
-    }
+    btn.classList.remove("active");
+    document.querySelectorAll("#itineraries-grid li").forEach(li => {
+        const id = parseInt(li.dataset.itineraryId);
+        li.style.display = PORTFOLIO_DATA.own_itinerary_ids.includes(id) ? "" : "none";
+    });
+}
 });
 
 

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -200,8 +200,7 @@ function renderProfile(user) {
 
     // Stats
     document.getElementById("stat-countries").textContent = Object.keys(user.countries).length;
-    document.getElementById("stat-posts").textContent = user.itineraries.length;
-
+    document.getElementById("stat-posts").textContent = PORTFOLIO_DATA.own_itinerary_ids.length;
 }
 
 function renderCountries(countries) {

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -254,9 +254,11 @@ function renderItineraries(itineraries) {
                 ${it.cover_image_url
                     ? `<img src="${it.cover_image_url}" class="w-full h-full object-cover">`
                     : `<div class="w-full h-full flex items-center justify-center text-4xl">✈️</div>`}
+                ${PORTFOLIO_DATA.own_itinerary_ids.includes(it.id) ? `
                 <div class="card-delete-overlay">
                     <button class="card-delete-btn"> X DELETE </button>
-                </div>
+                </div>` : ''}
+            </div>
             </div>
             <div class="p-3 flex-1">
                 <h3 class="text-xs font-bold text-blue-900 mb-1 leading-snug">${escapeHtml(it.title)}</h3>
@@ -268,7 +270,8 @@ function renderItineraries(itineraries) {
             </div>`;
 
         // Delete with confirmation
-        link.querySelector(".card-delete-btn").addEventListener("click", (e) => {
+        const deleteBtn = link.querySelector(".card-delete-btn");
+        if (deleteBtn) deleteBtn.addEventListener("click", (e) => {
             e.preventDefault();
             e.stopPropagation();
             if (!confirm(`Are you sure you want to delete "${it.title}"? This cannot be undone.`)) return;
@@ -302,6 +305,10 @@ function renderItineraries(itineraries) {
 
 // ── GLOBAL EDIT MODE ──
 document.getElementById("global-edit-btn").addEventListener("click", () => {
+    if (favouritesActive) {
+        alert("You can't edit while in Favourites view!");
+        return;
+    }
     const editBtn = document.getElementById("global-edit-btn");
     const isActive = editBtn.classList.toggle("active");
     document.querySelectorAll(".card-delete-overlay").forEach(overlay => {

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -285,8 +285,10 @@ function renderItineraries(itineraries) {
                 if (data.success) {
                     li.remove();
                     PORTFOLIO_DATA.itineraries = PORTFOLIO_DATA.itineraries.filter(x => x.id !== it.id);
-                    const remaining = PORTFOLIO_DATA.itineraries;
+                    PORTFOLIO_DATA.own_itinerary_ids = PORTFOLIO_DATA.own_itinerary_ids.filter(x => x !== it.id);
+                    const remaining = PORTFOLIO_DATA.itineraries.filter(x => PORTFOLIO_DATA.own_itinerary_ids.includes(x.id));
                     const countries = {};
+
                     remaining.forEach(x => { countries[x.location] = { flag: "🌍" }; });
                     renderCountries(countries);
                     document.getElementById("stat-posts").textContent = remaining.length;

--- a/app/static/js/portfolio-page.js
+++ b/app/static/js/portfolio-page.js
@@ -338,3 +338,11 @@ if (PORTFOLIO_DATA.banner_url) {
 renderProfile(PORTFOLIO_DATA);
 renderCountries(PORTFOLIO_DATA.countries);
 renderItineraries(PORTFOLIO_DATA.itineraries);
+
+// Hide other people's favourited itineraries by default
+document.querySelectorAll("#itineraries-grid li").forEach(li => {
+    const id = parseInt(li.dataset.itineraryId);
+    if (!PORTFOLIO_DATA.own_itinerary_ids.includes(id)) {
+        li.style.display = "none";
+    }
+});

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -98,6 +98,7 @@
         avatar_url: "{{ url_for('static', filename=user.avatar_url) if user and user.avatar_url else '' }}",
         banner_url: "{{ url_for('static', filename=user.banner_url) if user and user.banner_url else '' }}",
         favourited_ids: {{ favourited_ids | tojson }},
+        own_itinerary_ids: {{ own_itinerary_ids | tojson }},
         countries: {
             {% for it in itineraries %}
                 "{{ it.country }}": { flag: ""}{% if not loop.last %}, {% endif %}

--- a/app/templates/portfolio-page.html
+++ b/app/templates/portfolio-page.html
@@ -100,7 +100,8 @@
         favourited_ids: {{ favourited_ids | tojson }},
         own_itinerary_ids: {{ own_itinerary_ids | tojson }},
         countries: {
-            {% for it in itineraries %}
+            {% set own = itineraries | selectattr('user_id', 'equalto', user.id) | list %}
+            {% for it in own %}
                 "{{ it.country }}": { flag: ""}{% if not loop.last %}, {% endif %}
             {% endfor %}
         },


### PR DESCRIPTION
closes #145

- Updated `portfolio()` route in `main_routes.py` to fetch and pass favourited itineraries from other users
- Added `own_itinerary_ids` to `PORTFOLIO_DATA` in `portfolio-page.html`
- Fixed `countries` loop in `portfolio-page.html` to only include the user's own countries
- Updated `portfolio-page.js` to hide other people's favourited itineraries by default
- Updated favourites filter toggle to hide other people's itineraries when filter is turned off
- Hidden delete button on itineraries the user doesn't own
- Blocked edit mode while favourites filter is active
- Fixed counts to update correctly after deleting an itinerary