### PR TITLE
deleted click on and off as it was a duplicate

### DIFF
--- a/tests/system/test_portfolio_system.py
+++ b/tests/system/test_portfolio_system.py
@@ -251,25 +251,6 @@ class PortfolioSystemTests(unittest.TestCase):
         ]
         self.assertEqual(len(visible_cards), 1)
 
-        # Click star on
-        self.click_element_by_id("favourites-filter-btn")
-        self.wait.until(
-            lambda driver: any(
-                c.is_displayed()
-                for c in driver.find_elements(By.CLASS_NAME, "itinerary-card")
-            )
-        )
-
-       # Click star off
-        self.click_element_by_id("favourites-filter-btn")
-        import time
-        time.sleep(1)
-
-        visible_cards = [
-            c for c in self.driver.find_elements(By.CLASS_NAME, "itinerary-card")
-            if c.is_displayed()
-        ]
-        self.assertEqual(len(visible_cards), 0)
 
     # The edit button should be visible on the portfolio page.
     def test_edit_button_visible(self):


### PR DESCRIPTION
closes #154 
- Fixed `test_favourites_filter_shows_only_favourites` in `tests/system/test_portfolio_system.py`
- The toggle off logic was accidentally merged into the wrong test causing it to fail
- Removed the duplicate click on/off block from `test_favourites_filter_shows_only_favourites`